### PR TITLE
Destroy outdated yDocs, ensure persisted doc has loaded

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,11 +1,14 @@
 #!/usr/bin/env node
 
-import WebSocket from 'ws'
+import { WebSocketServer } from 'ws'
 import http from 'http'
 import * as number from 'lib0/number'
 import { setupWSConnection } from './utils.js'
 
-const wss = new WebSocket.Server({ noServer: true })
+const wss = new WebSocketServer({
+  noServer: true,
+  maxPayload: 256 * 1024 * 1024  // 256 MB (adjust as needed)
+})
 const host = process.env.HOST || 'localhost'
 const port = number.parseInt(process.env.PORT || '1234')
 
@@ -14,8 +17,14 @@ const server = http.createServer((_request, response) => {
   response.end('okay')
 })
 
-wss.on('connection', setupWSConnection)
-
+wss.on('connection', (ws, request) => {
+  ws.on('error', (error) => {
+    console.error('WebSocket error:', error)
+    // Gracefully close the connection on error
+    ws.close(1011, 'Internal server error') // 1011 is the status code for internal errors
+  })
+  setupWSConnection(ws, request)
+})
 server.on('upgrade', (request, socket, head) => {
   // You may check auth of request here..
   // Call `wss.HandleUpgrade` *after* you checked whether the client has access


### PR DESCRIPTION
I had trouble with memory management using y-websocket-server.  The server process was using several GBs of RAM.  I found that this was because the server was retaining yDocs in memory, even after the client had closed the connection. Secondly, when using LevelDB as a persistence database, the server was sending a sync message before LevelDB had supplied the document, with the result that empty documents were being served to clients.

This PR (a) includes code that is very careful to destroy YDocs when they are no longer needed (b) allows optional monitoring of memory use (set the environment variable VERBOSE non-zero to log connections and memory use to the console) and (c) awaits the loading of a persisted document before emitting the sync signal (the last relates to [event when documents have synced](https://discuss.yjs.dev/t/an-event-when-documents-have-synced/3884)).